### PR TITLE
Fixed duplication of investigation title in the output idf file.

### DIFF
--- a/hca-to-scea/hca2scea.py
+++ b/hca-to-scea/hca2scea.py
@@ -90,8 +90,7 @@ Comment[HCALastUpdateDate]\t{args.hca_update_date}
 Comment[SecondaryAccession]\t{args.project_uuid}
 Comment[EAExperimentType]\t{args.experiment_type}
 SDRF File\t{sdrf_file_name}
-
-Investigation Title\t{utils.reformat_value(xlsx_dict, "project_publications", "project.publications.title")[0]}
+Publication Title\t{utils.reformat_value(xlsx_dict, "project_publications", "project.publications.title")[0]}
 Publication Author List\t{author_list}
 PubMed ID\t{utils.reformat_value(xlsx_dict, "project_publications", "project.publications.pmid")[0]}
 Publication DOI\t{utils.reformat_value(xlsx_dict, "project_publications", "project.publications.doi")[0]}
@@ -129,8 +128,7 @@ Comment[HCALastUpdateDate]\t{args.hca_update_date}
 Comment[SecondaryAccession]\t{args.project_uuid}
 Comment[EAExperimentType]\t{args.experiment_type}
 SDRF File\t{sdrf_file_name}
-
-Investigation Title\t{utils.reformat_value(xlsx_dict, "project_publications", "project.publications.title")[0]}
+Publication Title\t{utils.reformat_value(xlsx_dict, "project_publications", "project.publications.title")[0]}
 Publication Author List\t{author_list}
 PubMed ID\t{utils.reformat_value(xlsx_dict, "project_publications", "project.publications.pmid")[0]}
 Publication DOI\t{utils.reformat_value(xlsx_dict, "project_publications", "project.publications.doi")[0]}

--- a/hca-to-scea/test/golden/expected/ERP121676_1/E-HCAD-100.idf.txt
+++ b/hca-to-scea/test/golden/expected/ERP121676_1/E-HCAD-100.idf.txt
@@ -28,8 +28,7 @@ Comment[HCALastUpdateDate]	2020-11-25
 Comment[SecondaryAccession]	955dfc2c-a8c6-4d04-aa4d-907610545d11
 Comment[EAExperimentType]	baseline
 SDRF File	E-HCAD-100.sdrf.txt
-
-Investigation Title	Population-scale single-cell RNA-seq profiling across dopaminergic neuron differentiation.
+Publication Title	Population-scale single-cell RNA-seq profiling across dopaminergic neuron differentiation.
 Publication Author List	Jerber J, Seaton DD, Cuomo ASE, Kumasaka N, Haldane J, Steer J, Patel M, Pearce D, Andersson M, Bonder MJ, Mountjoy E, Ghoussaini M, Lancaster MA, Marioni JC, Merkle FT, Stegle O, Gaffney DJ
 PubMed ID	
 Publication DOI	https://doi.org/10.1101/2020.05.21.103820

--- a/hca-to-scea/test/golden/expected/ERP121676_2/E-HCAD-100.idf.txt
+++ b/hca-to-scea/test/golden/expected/ERP121676_2/E-HCAD-100.idf.txt
@@ -28,8 +28,7 @@ Comment[HCALastUpdateDate]	2020-11-25
 Comment[SecondaryAccession]	955dfc2c-a8c6-4d04-aa4d-907610545d11
 Comment[EAExperimentType]	baseline
 SDRF File	E-HCAD-100.sdrf.txt
-
-Investigation Title	Population-scale single-cell RNA-seq profiling across dopaminergic neuron differentiation.
+Publication Title	Population-scale single-cell RNA-seq profiling across dopaminergic neuron differentiation.
 Publication Author List	Jerber J, Seaton DD, Cuomo ASE, Kumasaka N, Haldane J, Steer J, Patel M, Pearce D, Andersson M, Bonder MJ, Mountjoy E, Ghoussaini M, Lancaster MA, Marioni JC, Merkle FT, Stegle O, Gaffney DJ
 PubMed ID	
 Publication DOI	https://doi.org/10.1101/2020.05.21.103820

--- a/hca-to-scea/test/golden/expected/ERP121676_3/E-HCAD-100.idf.txt
+++ b/hca-to-scea/test/golden/expected/ERP121676_3/E-HCAD-100.idf.txt
@@ -28,8 +28,7 @@ Comment[HCALastUpdateDate]	2020-11-25
 Comment[SecondaryAccession]	955dfc2c-a8c6-4d04-aa4d-907610545d11
 Comment[EAExperimentType]	baseline
 SDRF File	E-HCAD-100.sdrf.txt
-
-Investigation Title	Population-scale single-cell RNA-seq profiling across dopaminergic neuron differentiation.
+Publication Title	Population-scale single-cell RNA-seq profiling across dopaminergic neuron differentiation.
 Publication Author List	Jerber J, Seaton DD, Cuomo ASE, Kumasaka N, Haldane J, Steer J, Patel M, Pearce D, Andersson M, Bonder MJ, Mountjoy E, Ghoussaini M, Lancaster MA, Marioni JC, Merkle FT, Stegle O, Gaffney DJ
 PubMed ID	
 Publication DOI	https://doi.org/10.1101/2020.05.21.103820

--- a/hca-to-scea/test/golden/expected/SRP151260/E-HCAD-50.idf.txt
+++ b/hca-to-scea/test/golden/expected/SRP151260/E-HCAD-50.idf.txt
@@ -28,8 +28,7 @@ Comment[HCALastUpdateDate]	2021-04-29
 Comment[SecondaryAccession]	c893cb57-5c9f-4f26-9312-21b85be84313
 Comment[EAExperimentType]	differential
 SDRF File	E-HCAD-50.sdrf.txt
-
-Investigation Title	Colonic epithelial cell diversity in health and inflammatory bowel disease.
+Publication Title	Colonic epithelial cell diversity in health and inflammatory bowel disease.
 Publication Author List	Parikh K, Antanaviciute A, Fawkner-Corbett D, Jagielowicz M, Aulicino A, Lagerholm C, Davis S, Kinchen J, Chen HH, Alham NK, Ashley N, Johnson E, Hublitz P, Bao L, Lukomska J, Andev RS, Björklund E, Kessler BM, Fischer R, Goldin R, Koohy H, Simmons A
 PubMed ID	30814735
 Publication DOI	10.1038/s41586-019-0992-y

--- a/hca-to-scea/test/golden/expected/SRP274475/E-HCAD-36.idf.txt
+++ b/hca-to-scea/test/golden/expected/SRP274475/E-HCAD-36.idf.txt
@@ -28,8 +28,7 @@ Comment[HCALastUpdateDate]	2020-11-25
 Comment[SecondaryAccession]	07073c12-8006-4710-a00b-23abdb814904
 Comment[EAExperimentType]	differential
 SDRF File	E-HCAD-36.sdrf.txt
-
-Investigation Title	Single-Cell Transcriptome Analysis Reveals Dynamic Cell Populations and Differential Gene Expression Patterns in Control and Aneurysmal Human Aortic Tissue.
+Publication Title	Single-Cell Transcriptome Analysis Reveals Dynamic Cell Populations and Differential Gene Expression Patterns in Control and Aneurysmal Human Aortic Tissue.
 Publication Author List	Li Y, Ren P, Dawson A, Vasquez HG, Ageedi W, Zhang C, Luo W, Chen R, Li Y, Kim S, Lu HS, Cassis LA, Coselli JS, Daugherty A, Shen YH, LeMaire SA
 PubMed ID	33017217
 Publication DOI	10.1161/CIRCULATIONAHA.120.046528


### PR DESCRIPTION
dcp-80
The Investigation title id duplicated in the output idf file.
The second instance should be "Publication Title".
There is also an extra blank line which should be removed.
These changes were made in this pull request.