### PR TITLE
Added option to skip empty secondary accessions

### DIFF
--- a/hca-to-scea/hca2scea.py
+++ b/hca-to-scea/hca2scea.py
@@ -471,7 +471,7 @@ def main():
     parser.add_argument(
         "-study",
         type=str,
-        required=True,
+        required=False,
         help="Please provide the SRA or ENA study accession."
     )
     parser.add_argument(

--- a/hca-to-scea/hca2scea.py
+++ b/hca-to-scea/hca2scea.py
@@ -24,6 +24,8 @@ def get_secondary_accessions(xlsx_dict, args):
     secondary_accessions.append(args.project_uuid)
     keys = ["project.geo_series_accessions","project.insdc_project_accessions","project.insdc_study_accessions","project.biostudies_accessions"]
     for key in keys:
+        if key not in xlsx_dict["project"]:
+            continue
         items = xlsx_dict["project"][key].fillna('')
         items = [item for item in items if item != '']
         if items:


### PR DESCRIPTION
Currently, if some of the accessions are missing from the spreadsheet, the script breaks in [line 29](https://github.com/ebi-ait/hca-to-scea-tools/blob/a13d0a98160a6d895c2b7b5b6fb9e6227a43bf7f/hca-to-scea/hca2scea.py#L27)
```python
xlsx_dict["project"][key]
```

To avoid that, we have to skip if no accession if present.